### PR TITLE
Implement versioned config schema for CIRISNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ __pycache__
 *.sw2
 *.sw1
 *.sw0
+CIRISAgent/

--- a/cirisnode/api/health/routes.py
+++ b/cirisnode/api/health/routes.py
@@ -1,14 +1,15 @@
 from fastapi import APIRouter, Depends, Request
-from cirisnode.config import settings
 from datetime import datetime
+from cirisnode.dao.config_dao import get_config
+from cirisnode.schema.config_models import CIRISConfigV1
 
 router = APIRouter(prefix="/api/v1/health", tags=["health"])
 
 @router.get("")
-def health_check(request: Request):
+def health_check(request: Request, config: CIRISConfigV1 = Depends(get_config)):
     return {
         "status": "ok",
-        "version": "1.0.0",
+        "version": config.version,
         "pubkey": "dummy-pubkey",
         "message": "CIRISNode is healthy",
         "timestamp": datetime.utcnow().isoformat()

--- a/cirisnode/dao/config_dao.py
+++ b/cirisnode/dao/config_dao.py
@@ -1,0 +1,55 @@
+import json
+import sqlite3
+
+from cirisnode.schema.config_models import CIRISConfigV1, LLMConfigV1
+
+
+class ConfigDAO:
+    """Data access object for CIRISNode configuration."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS config (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                version INTEGER NOT NULL,
+                config_json TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def get_config(self) -> CIRISConfigV1:
+        cur = self.conn.execute("SELECT config_json FROM config WHERE id = 1")
+        row = cur.fetchone()
+        if row is None:
+            default = CIRISConfigV1(llm=LLMConfigV1())
+            self.save_config(default)
+            return default
+        data = json.loads(row[0])
+        return CIRISConfigV1.model_validate(data)
+
+    def save_config(self, config: CIRISConfigV1) -> None:
+        config_json = config.model_dump_json()
+        self.conn.execute(
+            "INSERT OR REPLACE INTO config (id, version, config_json) VALUES (1, ?, ?)",
+            (config.version, config_json),
+        )
+        self.conn.commit()
+
+
+def get_config_dao(db_conn: sqlite3.Connection) -> ConfigDAO:
+    return ConfigDAO(db_conn)
+
+from fastapi import Depends
+from cirisnode.database import get_db
+
+
+def get_config(db=Depends(get_db)) -> CIRISConfigV1:
+    conn = next(db) if hasattr(db, "__iter__") and not isinstance(db, (str, bytes)) else db
+    dao = ConfigDAO(conn)
+    return dao.get_config()

--- a/cirisnode/db/schema.sql
+++ b/cirisnode/db/schema.sql
@@ -37,3 +37,10 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     details JSONB,
     archived INTEGER DEFAULT 0
 );
+
+-- Versioned configuration stored as a single JSON blob
+CREATE TABLE IF NOT EXISTS config (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    version INTEGER NOT NULL,
+    config_json TEXT NOT NULL
+);

--- a/cirisnode/schema/config_models.py
+++ b/cirisnode/schema/config_models.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, HttpUrl, field_validator
+from typing import Optional
+
+class LLMConfigV1(BaseModel):
+    api_base: Optional[HttpUrl] = None
+    model_name: Optional[str] = None
+
+    @field_validator('api_base')
+    def no_trailing_slash(cls, v):
+        if v and str(v).endswith('/'):
+            raise ValueError("api_base must not have a trailing slash")
+        return v
+
+    @field_validator('model_name')
+    def model_required_if_api_base(cls, v, values):
+        if values.get('api_base') and not v:
+            raise ValueError("model_name is required if api_base is set")
+        return v
+
+class CIRISConfigV1(BaseModel):
+    version: int = 1
+    llm: LLMConfigV1

--- a/schema.sql
+++ b/schema.sql
@@ -56,3 +56,10 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     payload_sha256 TEXT,
     details TEXT
 );
+
+-- Versioned configuration stored as a single JSON blob
+CREATE TABLE IF NOT EXISTS config (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    version INTEGER NOT NULL,
+    config_json TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- add Pydantic v2 config schema models
- create ConfigDAO for reading/writing config JSON blobs
- expose config via dependency injection
- return config version from health endpoint
- update DB schema with new `config` table
- ignore CIRISAgent directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*